### PR TITLE
Update dependencies, improve macOS support, and enhance output formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +712,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,10 +870,11 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "piko"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "colored",
+ "dirs",
  "reqwest",
  "serde",
  "sysinfo",
@@ -913,6 +951,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1239,6 +1288,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ assets = [
 
 [package]
 name = "piko"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 authors = ["Elxes04"]
@@ -24,3 +24,4 @@ toml = "0.5"
 whoami = "1.2"
 sysinfo = "0.29"
 colored = "2.0"
+dirs = "6.0.0"

--- a/config/default_config.toml
+++ b/config/default_config.toml
@@ -26,22 +26,22 @@ font_size = 12
 alignment = "left"
 
 [colors]
-OS = "#0000FF"  # Blue
-Username = "#008000"  # Green
-Hostname = "#FFFF00"  # Yellow
-"Desktop Environment" = "#FF00FF"  # Magenta
-Memory = "#00FFFF"  # Cyan
-Disks = "#FF00FF"  # Magenta
-"CPU Model" = "#FF0000"  # Red
-"GPU Model" = "#00FF00"  # Bright Green
-"Kernel Version" = "#FFA500"  # Orange
-"Display Server" = "#00CED1"  # Dark Turquoise
+OS = "#1E90FF"  # Dodger Blue
+Username = "#32CD32"  # Lime Green
+Hostname = "#FFD700"  # Gold
+"Desktop Environment" = "#FF69B4"  # Hot Pink
+Memory = "#00FA9A"  # Medium Spring Green
+Disks = "#FF4500"  # Orange Red
+"CPU Model" = "#8A2BE2"  # Blue Violet
+"GPU Model" = "#7FFF00"  # Chartreuse
+"Kernel Version" = "#FF6347"  # Tomato
+"Display Server" = "#4682B4"  # Steel Blue
 
 [symbols]
 OS = "\U0001f5a5\ufe0f"
 Username = "\U0001f464"
 Hostname = "\U0001f4e1"
-Desktop_Environment = "\U0001f5bc\ufe0f"
+"Desktop Environment" = "\U0001f320"
 Memory = "\U0001f4be"
 Disks = "\U0001f4c2"
 "CPU Model" = "\U0001f9ea"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,14 @@ struct Cli {
 }
 
 fn get_default_config_path() -> PathBuf {
-    PathBuf::from("/etc/piko/default_config.toml")
+    if cfg!(target_os = "macos") {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("piko")
+            .join("default_config.toml")
+    } else {
+        PathBuf::from("/etc/piko/default_config.toml")
+    }
 }
 
 fn ensure_default_config_exists() {
@@ -31,15 +38,21 @@ fn ensure_default_config_exists() {
 
         let parent_dir = config_path.parent().unwrap();
 
-        // It is necessary to create the directory and write with root privileges
-        let result = Command::new("sudo")
-            .args(&["mkdir", "-p", parent_dir.to_str().unwrap()])
-            .status()
-            .expect("Failed to create the directory");
+        // Create the directory depending on the operating system
+        if cfg!(target_os = "macos") {
+            fs::create_dir_all(parent_dir)
+                .expect("Failed to create the configuration directory on macOS");
+        } else {
+            // On Linux or other systems: use sudo to create the directory
+            let result = Command::new("sudo")
+                .args(&["mkdir", "-p", parent_dir.to_str().unwrap()])
+                .status()
+                .expect("Failed to create the configuration directory");
 
-        if !result.success() {
-            eprintln!("Error creating the configuration directory.");
-            std::process::exit(1);
+            if !result.success() {
+                eprintln!("Error creating the configuration directory.");
+                std::process::exit(1);
+            }
         }
 
         // Download the file
@@ -47,29 +60,35 @@ fn ensure_default_config_exists() {
         let response = get(url).expect("Unable to download the configuration file");
         let content = response.text().expect("Error reading the content");
 
-        // Write the file with sudo (using `tee` to handle input from stdin)
-        let mut child = Command::new("sudo")
-            .arg("tee")
-            .arg(config_path.to_str().unwrap())
-            .stdin(std::process::Stdio::piped())
-            .spawn()
-            .expect("Unable to start sudo tee");
-
-        child.stdin
-            .as_mut()
-            .expect("Unable to open stdin")
-            .write_all(content.as_bytes())
-            .expect("Unable to write the file");
-
-        let output = child.wait().expect("Error during file writing");
-        if output.success() {
-            println!("Configuration file downloaded to {}", config_path.display());
+        if cfg!(target_os = "macos") {
+            // Directly write the file on macOS
+            fs::write(&config_path, content).expect("Unable to write the configuration file");
         } else {
-            eprintln!("Error during the configuration file writing");
-            std::process::exit(1);
+            // Use sudo and tee to write with root permissions on other systems
+            let mut child = Command::new("sudo")
+                .arg("tee")
+                .arg(config_path.to_str().unwrap())
+                .stdin(std::process::Stdio::piped())
+                .spawn()
+                .expect("Unable to start sudo tee");
+
+            child.stdin
+                .as_mut()
+                .expect("Unable to open stdin")
+                .write_all(content.as_bytes())
+                .expect("Unable to write the file");
+
+            let output = child.wait().expect("Error during file writing");
+            if !output.success() {
+                eprintln!("Error during the configuration file writing");
+                std::process::exit(1);
+            }
         }
+
+        println!("Configuration file downloaded to {}", config_path.display());
     }
 }
+
 
 fn load_config(config_path: Option<PathBuf>) -> Value {
     let path = config_path.unwrap_or_else(get_default_config_path);

--- a/src/output.rs
+++ b/src/output.rs
@@ -24,14 +24,6 @@ impl OutputConfig {
     }
 }
 
-pub fn format_output(system_info: &str, config: &OutputConfig) -> String {
-    match config.layout.as_str() {
-        "simple" => format!("System Information:\n{}", system_info),
-        "detailed" => format!("=== System Information ===\n{}", system_info),
-        _ => format!("Unsupported layout. Defaulting to simple:\n{}", system_info),
-    }
-}
-
 pub fn display_output(system_info: &HashMap<String, String>, config: &Value) {
     // Get the ordered keys to display
     let info_keys = config


### PR DESCRIPTION
- Added new dependencies: `dirs`, `dirs-sys`, `libredox`, `option-ext`, `redox_users`, `thiserror`, and `thiserror-impl`.
- Updated version of `piko` to 0.2.0.
- Modified default configuration path for macOS.
- Improved configuration file handling for macOS and Linux.
- Enhanced GPU model extraction logic.
- Removed unused `format_output` function from output module.
- Updated color scheme in default configuration.